### PR TITLE
Support `no_std` environment.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,14 @@ keywords = ["reference", "sibling", "field", "owning"]
 [lib]
 name = "owning_ref"
 
+[features]
+default = ["std"]
+std = ["stable_deref_trait/std"]
+
 [dependencies]
-stable_deref_trait = "1.0.0"
 maybe-dangling = "0.1.1"
+
+[dependencies.stable_deref_trait]
+version = "1.2.0"
+default-features = false
+features = ["alloc"]


### PR DESCRIPTION
Added a feature `std`, which is enabled by default. When disabled, fallback to use the counterparts in the `core` library if possible. Enable `std` in `stable_deref_trait` only when `std` on this crate is enabled.