### PR TITLE
Minimal fixes to use maybe-dangling crate to address some of the miri errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ name = "owning_ref"
 
 [dependencies]
 stable_deref_trait = "1.0.0"
+maybe-dangling = "0.1.1"


### PR DESCRIPTION
This fixes some of the failures under miri reported here: https://github.com/noamtashma/owning-ref-rs/issues/3

Unfortunately the whole crate still doesn't have a clean bill of health because several I can't figure out how to guarantee soundness for `map_owner` and `erase_owner`.